### PR TITLE
feature: import-lite integration & tsconfig fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sj-distributor/eslint-config",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "SJ Distributor Avenger Team ESLint Config",
   "keywords": [
     "eslint",
@@ -36,6 +36,7 @@
     "@typescript-eslint/parser": "^8.57.1",
     "@typescript-eslint/type-utils": "^8.57.1",
     "@typescript-eslint/utils": "^8.57.1",
+    "eslint-plugin-import-lite": "^0.6.0",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "eslint-plugin-unicorn": "^63.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@typescript-eslint/utils':
         specifier: ^8.57.1
         version: 8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      eslint-plugin-import-lite:
+        specifier: ^0.6.0
+        version: 0.6.0(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks:
         specifier: ^7.0.1
         version: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -1243,6 +1246,12 @@ packages:
     peerDependencies:
       '@babel/eslint-parser': ^7.12.0
       eslint: ^8.1.0
+
+  eslint-plugin-import-lite@0.6.0:
+    resolution: {integrity: sha512-80vevx2A7i3H7n1/6pqDO8cc5wRz6OwLDvIyVl9UflBV1N1f46e9Ihzi65IOLYoSxM6YykK2fTw1xm0Ixx6aTQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^9.0.0 || ^10.0.0
 
   eslint-plugin-jest@29.15.0:
     resolution: {integrity: sha512-ZCGr7vTH2WSo2hrK5oM2RULFmMruQ7W3cX7YfwoTiPfzTGTFBMmrVIz45jZHd++cGKj/kWf02li/RhTGcANJSA==}
@@ -3827,6 +3836,10 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       lodash: 4.17.23
       string-natural-compare: 3.0.1
+
+  eslint-plugin-import-lite@0.6.0(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.6.1)
 
   eslint-plugin-jest@29.15.0(@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
     dependencies:

--- a/scripts/typegen.ts
+++ b/scripts/typegen.ts
@@ -4,12 +4,7 @@ import { builtinRules } from 'eslint/use-at-your-own-risk';
 import type { Linter } from 'eslint';
 import { ignores, importLiteConfig, javascript, react, stylistic, typescript, unicorn } from '../src';
 
-generateTypeDefinitions().catch((err: unknown) => {
-  // eslint-disable-next-line no-console
-  console.error(err);
-});
-
-export async function generateTypeDefinitions() {
+async function generateTypeDefinitions() {
   const configs: Linter.Config[] = [
     {
       name: 'eslint/builtin',
@@ -41,3 +36,8 @@ export type ConfigNames = ${configNames.map(i => `'${i}'`).join(' | ')}
 
   await fs.writeFile('src/typegen.d.ts', dts);
 }
+
+generateTypeDefinitions().catch((err: unknown) => {
+  // eslint-disable-next-line no-console
+  console.error(err);
+});

--- a/scripts/typegen.ts
+++ b/scripts/typegen.ts
@@ -4,6 +4,11 @@ import { builtinRules } from 'eslint/use-at-your-own-risk';
 import type { Linter } from 'eslint';
 import { ignores, importLiteConfig, javascript, react, stylistic, typescript, unicorn } from '../src';
 
+generateTypeDefinitions().catch((err: unknown) => {
+  // eslint-disable-next-line no-console
+  console.error(err);
+});
+
 export async function generateTypeDefinitions() {
   const configs: Linter.Config[] = [
     {
@@ -36,5 +41,3 @@ export type ConfigNames = ${configNames.map(i => `'${i}'`).join(' | ')}
 
   await fs.writeFile('src/typegen.d.ts', dts);
 }
-
-generateTypeDefinitions().catch(console.error);

--- a/scripts/typegen.ts
+++ b/scripts/typegen.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import { flatConfigsToRulesDTS } from 'eslint-typegen/core';
 import { builtinRules } from 'eslint/use-at-your-own-risk';
 import type { Linter } from 'eslint';
-import { ignores, javascript, react, stylistic, typescript, unicorn } from '../src';
+import { ignores, importLiteConfig, javascript, react, stylistic, typescript, unicorn } from '../src';
 
 export async function generateTypeDefinitions() {
   const configs: Linter.Config[] = [
@@ -16,6 +16,7 @@ export async function generateTypeDefinitions() {
     },
     ...ignores(),
     ...(await javascript()),
+    ...importLiteConfig(),
     ...(await typescript()),
     ...(await react()),
     ...stylistic(),

--- a/src/configs/import-lite.ts
+++ b/src/configs/import-lite.ts
@@ -1,0 +1,42 @@
+import importLite from 'eslint-plugin-import-lite';
+import type { TypedFlatConfigItem, Overrides } from '../types';
+
+export interface ImportLiteOptions {
+  files?: string[];
+  overrides?: Overrides;
+}
+
+export function importLiteConfig(
+  options: ImportLiteOptions = {},
+): TypedFlatConfigItem[] {
+  const {
+    files = ['**/*.{js,mjs,cjs,ts,tsx,mts,cts,jsx}'],
+    overrides = {},
+  } = options;
+
+  return [
+    {
+      name: 'sj-distributor/import-lite/rules',
+      files,
+      plugins: {
+        'import-lite': importLite,
+      },
+      rules: {
+        'import-lite/no-duplicates': 'error',
+        'import-lite/first': 'error',
+        'import-lite/newline-after-import': 'error',
+        'import-lite/no-mutable-exports': 'error',
+        'import-lite/exports-last': 'error',
+        'import-lite/no-named-default': 'error',
+
+        // TypeScript handles this natively
+        'import-lite/consistent-type-specifier-style': 'off',
+      },
+    },
+    {
+      name: 'sj-distributor/import-lite/overrides',
+      files,
+      rules: overrides,
+    },
+  ];
+}

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -1,4 +1,5 @@
 export * from './ignores';
+export * from './import-lite';
 export * from './javascript';
 export * from './react';
 export * from './react-native';

--- a/src/configs/javascript.ts
+++ b/src/configs/javascript.ts
@@ -1,8 +1,7 @@
 import js from '@eslint/js';
-import type { TypedFlatConfigItem } from '../types';
+import type { TypedFlatConfigItem, Overrides } from '../types';
 import unusedImports from 'eslint-plugin-unused-imports';
 import globals from 'globals';
-import type { Overrides } from '../types';
 
 export async function javascript(
   options: {

--- a/src/configs/react-native.ts
+++ b/src/configs/react-native.ts
@@ -1,5 +1,4 @@
-import type { TypedFlatConfigItem } from '../types';
-import type { Overrides } from '../types';
+import type { TypedFlatConfigItem, Overrides } from '../types';
 import { interopDefault } from '../utils';
 
 export interface ReactNativeOptions {

--- a/src/configs/react.ts
+++ b/src/configs/react.ts
@@ -1,5 +1,4 @@
-import type { TypedFlatConfigItem } from '../types';
-import type { Overrides } from '../types';
+import type { TypedFlatConfigItem, Overrides } from '../types';
 import { interopDefault } from '../utils';
 
 export interface ReactOptions {

--- a/src/configs/stylistic.ts
+++ b/src/configs/stylistic.ts
@@ -1,6 +1,5 @@
 import stylisticPlugin from '@stylistic/eslint-plugin';
-import type { TypedFlatConfigItem } from '../types';
-import type { Overrides } from '../types';
+import type { TypedFlatConfigItem, Overrides } from '../types';
 
 export interface StylisticOptions {
   indent?: number | 'tab';

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import { interopDefault, renameRules } from '../utils';
 import type { Overrides, TypedFlatConfigItem } from '../types';
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { ignores, javascript, react, reactNative, stylistic, typescript, unicorn } from './configs';
+import { ignores, importLiteConfig, javascript, react, reactNative, stylistic, typescript, unicorn } from './configs';
 import type { AvengerOptions, UserConfig } from './types';
 
 export async function avenger(
@@ -11,6 +11,7 @@ export async function avenger(
     typescript: enableTypescript = true,
     stylistic: enableStylistic = true,
     unicorn: enableUnicorn = true,
+    importLite: enableImportLite = true,
     ignores: customIgnores = [],
   } = options;
 
@@ -22,13 +23,19 @@ export async function avenger(
   // 2. JavaScript (always enabled)
   configs.push(...(await javascript()));
 
-  // 3. TypeScript
+  // 3. Import-lite
+  if (enableImportLite) {
+    const importLiteOptions = typeof enableImportLite === 'object' ? enableImportLite : {};
+    configs.push(...importLiteConfig(importLiteOptions));
+  }
+
+  // 4. TypeScript
   if (enableTypescript) {
     const tsOptions = typeof enableTypescript === 'object' ? enableTypescript : {};
     configs.push(...(await typescript(tsOptions)));
   }
 
-  // 4. React
+  // 5. React
   if (enableReact) {
     const reactOptions = typeof enableReact === 'object' ? enableReact : {};
     if (enableTypescript && reactOptions.typescript === undefined) {
@@ -40,24 +47,24 @@ export async function avenger(
     configs.push(...(await react(reactOptions)));
   }
 
-  // 5. React Native
+  // 6. React Native
   if (enableReactNative) {
     const reactNativeOptions = typeof enableReactNative === 'object' ? enableReactNative : {};
     configs.push(...(await reactNative(reactNativeOptions)));
   }
 
-  // 6. Stylistic
+  // 7. Stylistic
   if (enableStylistic) {
     const stylisticOptions = typeof enableStylistic === 'object' ? enableStylistic : {};
     configs.push(...stylistic(stylisticOptions));
   }
 
-  // 7. Unicorn
+  // 8. Unicorn
   if (enableUnicorn) {
     configs.push(...unicorn());
   }
 
-  // 8. User overrides
+  // 9. User overrides
   if (userConfigs.length > 0) {
     configs.push(...userConfigs);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { Linter } from 'eslint';
+import type { ImportLiteOptions } from './configs/import-lite';
 import type { ReactOptions } from './configs/react';
 import type { ReactNativeOptions } from './configs/react-native';
 import type { StylisticOptions } from './configs/stylistic';
@@ -58,6 +59,12 @@ export interface AvengerOptions {
    * @default true
    */
   stylistic?: boolean | StylisticOptions;
+
+  /**
+   * Enable import-lite rules.
+   * @default true
+   */
+  importLite?: boolean | ImportLiteOptions;
 
   /**
    * Enable unicorn rules.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "baseUrl": ".",
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "include": ["src", "scripts", "eslint.config.ts"]
 }


### PR DESCRIPTION
## Included Changes

- [x] Add `eslint-plugin-import-lite` integration (#new)
- [x] Enable 6 import rules by default (no-duplicates, first, newline-after-import, no-mutable-exports, exports-last, no-named-default)
- [x] Add `importLite` option to `AvengerOptions`
- [x] Fix implicit `process` global → explicit `import process from 'node:process'`
- [x] Remove deprecated `baseUrl` from tsconfig
- [x] Add `"types": ["node"]` to tsconfig
- [x] Consolidate type imports